### PR TITLE
Add fallback camcorder profiles

### DIFF
--- a/LandscapeVideoCapture/src/com/jmolsmobile/landscapevideocapture/camera/CameraWrapper.java
+++ b/LandscapeVideoCapture/src/com/jmolsmobile/landscapevideocapture/camera/CameraWrapper.java
@@ -90,7 +90,12 @@ public class CameraWrapper {
     }
 
     public CamcorderProfile getBaseRecordingProfile() {
-        return CamcorderProfile.get(CamcorderProfile.QUALITY_720P);
+        if (CamcorderProfile.hasProfile(CamcorderProfile.QUALITY_720P))
+            return CamcorderProfile.get(CamcorderProfile.QUALITY_720P);
+        else if (CamcorderProfile.hasProfile(CamcorderProfile.QUALITY_480P))
+            return CamcorderProfile.get(CamcorderProfile.QUALITY_480P);
+        else
+            return CamcorderProfile.get(CamcorderProfile.QUALITY_HIGH);
     }
 
     public void configureForPreview(int viewWidth, int viewHeight) {


### PR DESCRIPTION
CameraWrapper#getBaseRecordingProfile will return null when a device does not support the given profile. 
From the documentation "QUALITY_LOW, QUALITY_HIGH are guaranteed to be supported, while other levels may or may not be supported"